### PR TITLE
Update list of CIP editors

### DIFF
--- a/app/contributors/page.js
+++ b/app/contributors/page.js
@@ -7,14 +7,6 @@ export default function Editors() {
   // List of editors
   const Editors = [
     {
-      name: 'Matthias Benkort',
-      github_link: 'https://github.com/KtorZ',
-    },
-    {
-      name: 'Sebastien Guillemot',
-      github_link: 'https://github.com/SebastienGllmt',
-    },
-    {
       name: 'Robert Phair',
       github_link: 'https://github.com/rphair',
     },
@@ -25,6 +17,10 @@ export default function Editors() {
     {
       name: 'Adam Dean',
       github_link: 'https://github.com/Crypto2099',
+    },
+    {
+      name: 'Thomas Vellekoop',
+      github_link: 'https://github.com/perturbing',
     },
   ]
 


### PR DESCRIPTION
To reflect:
* https://github.com/cardano-foundation/CIPs/pull/901
* https://github.com/cardano-foundation/CIPs/pull/905

Personally I think prior editors should also be listed (and hope to update CIP-0001 with that information soon) but I'm not suggesting it here.