### PR TITLE
Merge #34 into master

### DIFF
--- a/app/contributors/page.js
+++ b/app/contributors/page.js
@@ -7,14 +7,6 @@ export default function Editors() {
   // List of editors
   const Editors = [
     {
-      name: 'Matthias Benkort',
-      github_link: 'https://github.com/KtorZ',
-    },
-    {
-      name: 'Sebastien Guillemot',
-      github_link: 'https://github.com/SebastienGllmt',
-    },
-    {
       name: 'Robert Phair',
       github_link: 'https://github.com/rphair',
     },
@@ -25,6 +17,10 @@ export default function Editors() {
     {
       name: 'Adam Dean',
       github_link: 'https://github.com/Crypto2099',
+    },
+    {
+      name: 'Thomas Vellekoop',
+      github_link: 'https://github.com/perturbing',
     },
   ]
 


### PR DESCRIPTION
This should put everything from `staging` into `master` up through & including https://github.com/cardano-foundation/cf-cip-frontend/pull/34.

@ptrdsh if I have misunderstood your request in https://github.com/cardano-foundation/cf-cip-frontend/pull/34#issuecomment-2357064041, or have based this branch improperly to show those extra commits, please let me know exactly how I should submit this so that doesn't include all the changes to `staging` up to this time.