### PR TITLE
Update CIP editors list

### DIFF
--- a/app/contributors/page.js
+++ b/app/contributors/page.js
@@ -15,10 +15,6 @@ export default function Editors() {
       github_link: 'https://github.com/Ryun1',
     },
     {
-      name: 'Adam Dean',
-      github_link: 'https://github.com/Crypto2099',
-    },
-    {
       name: 'Thomas Vellekoop',
       github_link: 'https://github.com/perturbing',
     },


### PR DESCRIPTION
Removing retired editor (gone for months now); confirmed by:
* https://github.com/cardano-foundation/CIPs/pull/1161 (removal)
* https://github.com/cardano-foundation/CIPs#editors (current state)